### PR TITLE
Add initial version of revpi-bluetooth

### DIFF
--- a/lib/systemd/system/revpi-bthelper@.service
+++ b/lib/systemd/system/revpi-bthelper@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Revolution Pi bluetooth helper for %I
+Requires=bluetooth.service
+After=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/revpi-bthelper %I
+RemainAfterExit=yes

--- a/lib/systemd/system/revpi-hciuart@.service
+++ b/lib/systemd/system/revpi-hciuart@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Revolution Pi Bluetooth Device %i
+After=systemd-udev-settle.service
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/revpi-btuart %i

--- a/lib/udev/rules.d/90-revpi-bluetooth.rules
+++ b/lib/udev/rules.d/90-revpi-bluetooth.rules
@@ -1,0 +1,5 @@
+# Revolution Pi bluetooth module: start the hciuart service
+ACTION=="add", SUBSYSTEM=="tty" DEVPATH=="*/usb1/1-1/1-1.5/1-1.5:1.0/*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-hciuart@%k.service"
+
+# Revolution Pi bluetooth module: start the revpi-bthelper service
+ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-bthelper@%k.service"

--- a/usr/bin/revpi-btuart
+++ b/usr/bin/revpi-btuart
@@ -1,0 +1,8 @@
+#!/bin/sh
+# referenced pi-bluetooth, bluetooth attach for Revolution Pi BT
+
+HCIATTACH=/usr/bin/hciattach
+TTYDEVNAME="$1"
+
+# Revolution Flat limits the speed to 2000000
+$HCIATTACH "$TTYDEVNAME" bcm43xx 2000000 flow

--- a/usr/sbin/revpi-bthelper
+++ b/usr/sbin/revpi-bthelper
@@ -1,0 +1,27 @@
+#!/bin/sh
+# referenced pi-bluetooth, bluetooth helper for Revolution Pi BT
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+	echo "Usage: $0 <bluetooth hci device>"
+	exit 0
+fi
+
+dev=$1
+
+# Need to bring hci up before looking at MAC as it can be all zeros during init
+/bin/hciconfig "$dev" up
+
+if ! /bin/hciconfig "$dev" | grep -q "Bus: UART"; then
+	echo Not UART-attached BT Modem
+	exit 0
+fi
+
+# Force reinitialisation to allow extra features such as Secure Simple Pairing
+# to be enabled
+/usr/bin/bluetoothctl power off
+/usr/bin/bluetoothctl power on
+
+# Route SCO packets to the HCI interface (enables HFP/HSP)
+/usr/bin/hcitool -i $dev cmd 0x3f 0x1c 0x01 0x02 0x00 0x01 0x01 > /dev/null


### PR DESCRIPTION
The pi-bluetooth configures the bluetooth for raspberry pi devices with
concerning hardware's detail, which is thus not applicable for revolution pi
devices.

To do the equivalent configuration on revolution pi, this package with name
as revpi-bluetooth is created with reference to pi-bluetooth package.

Signed-off-by: Zhi Han <z.han@kunbus.com>