### PR TITLE
Flat: Reset the bt module before hciattach (REVPI-1609)

### DIFF
--- a/usr/bin/revpi-btuart
+++ b/usr/bin/revpi-btuart
@@ -4,5 +4,18 @@
 HCIATTACH=/usr/bin/hciattach
 TTYDEVNAME="$1"
 
+# RevPi Flat: The BT_REG_ON signal is connected to the GPIO11 of the expander.
+BT_REG_ON_GPIO=11
+GPIOCHIP="$(basename /sys/devices/platform/soc/3f804000.i2c/i2c-1/1-0020/gpiochip?)"
+if [ "$GPIOCHIP" != "gpiochip*" ]; then
+	# Reset the bt module in RevPi Flat
+	gpioset "$GPIOCHIP" $BT_REG_ON_GPIO=0
+	sleep 0.1
+	gpioset "$GPIOCHIP" $BT_REG_ON_GPIO=1
+	sleep 0.1
+else
+	>&2 echo "$1: ERROR: Can't find the correct gpiochip to reset the bt module."
+fi
+
 # Revolution Flat limits the speed to 2000000
 $HCIATTACH "$TTYDEVNAME" bcm43xx 2000000 flow


### PR DESCRIPTION
On the RevPi Flat the bt module is connected to a USB UART. This creates
some problems. Currently the kernel is not able to use serdev for the
USB UART. Which in return makes it impossible to define the bluetooth
device in the devicetree. The bt driver has a function to handle the
BT_REG_ON pin of the bt module. But this is not possible without the
devicetree.

Without a proper reset of the bt module the module doesn't respond to
the hciattach. As the module is not reset during a reboot, we need to
reset the module before we attach the module.

We toggle the BT_REG_ON pin to reset the module. The pin is connected to
the GPIO11 on the GPIO expander on the top board. The BT power-on reset
(POR) circuit is out of reset after BT_REG_ON goes High.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>