### PR TITLE
Create a new package release revpi-bluetooth (v1.0.1-1)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+revpi-bluetooth (1.0.1-1) buster; urgency=medium
+
+  * Flat: Reset the bt module before hciattach
+  * Add gpiod as dependency
+  * gbp.conf: Add debian-tag, debian-tag-msg and pristine-tar options
+  * Fix copyright file: missing-license-paragraph-in-dep5-copyright
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Fri, 05 Nov 2021 10:47:44 +0100
+
 revpi-bluetooth (1.0.0-3) buster; urgency=low
 
   * Remove the systemd related option and overides from rules.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Vcs-Git: https://github.com/RevolutionPi/revpi-bluetooth.git
 
 Package: revpi-bluetooth
 Architecture: all
-Depends: ${misc:Depends}, bluez, bluez-firmware
+Depends: ${misc:Depends}, bluez, bluez-firmware, gpiod
 Description: Revolution Pi bluetooth
  Setup Revolution Pi bluetooth devices on boot

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,4 +2,22 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
 Copyright: 2021 KUNBUS GmbH
-License: GPL-2.0
+License: GPL-2+
+
+License: GPL-2+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ version 2 can be found in ‘/usr/share/common-licenses/GPL-2’.

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,4 +1,6 @@
 [DEFAULT]
 upstream-tag = v%(version)s
 debian-branch=raspios/buster
-
+debian-tag = raspios/%(version)s
+debian-tag-msg = %(pkg)s RaspiOS release %(version)s
+pristine-tar = True

--- a/usr/bin/revpi-btuart
+++ b/usr/bin/revpi-btuart
@@ -4,5 +4,18 @@
 HCIATTACH=/usr/bin/hciattach
 TTYDEVNAME="$1"
 
+# RevPi Flat: The BT_REG_ON signal is connected to the GPIO11 of the expander.
+BT_REG_ON_GPIO=11
+GPIOCHIP="$(basename /sys/devices/platform/soc/3f804000.i2c/i2c-1/1-0020/gpiochip?)"
+if [ "$GPIOCHIP" != "gpiochip*" ]; then
+	# Reset the bt module in RevPi Flat
+	gpioset "$GPIOCHIP" $BT_REG_ON_GPIO=0
+	sleep 0.1
+	gpioset "$GPIOCHIP" $BT_REG_ON_GPIO=1
+	sleep 0.1
+else
+	>&2 echo "$1: ERROR: Can't find the correct gpiochip to reset the bt module."
+fi
+
 # Revolution Flat limits the speed to 2000000
 $HCIATTACH "$TTYDEVNAME" bcm43xx 2000000 flow


### PR DESCRIPTION
The new package will contain the following changes:

  * Flat: Reset the bt module before hciattach
  * Add gpiod as dependency
  * gbp.conf: Add debian-tag, debian-tag-msg and pristine-tar options
  * Fix copyright file: missing-license-paragraph-in-dep5-copyright