### PR TITLE
Add check that the rules are only run on Flat

### DIFF
--- a/lib/udev/rules.d/90-revpi-bluetooth.rules
+++ b/lib/udev/rules.d/90-revpi-bluetooth.rules
@@ -1,5 +1,6 @@
-# Revolution Pi bluetooth module: start the hciuart service
-ACTION=="add", SUBSYSTEM=="tty" DEVPATH=="*/usb1/1-1/1-1.5/1-1.5:1.0/*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-hciuart@%k.service"
+PROGRAM="/bin/grep -Fz -m 1 'kunbus,revpi-' /sys/firmware/devicetree/base/compatible"
 
+# Revolution Pi bluetooth module: start the hciuart service
+RESULT=="kunbus,revpi-flat", ACTION=="add", SUBSYSTEM=="tty" DEVPATH=="*/usb1/1-1/1-1.5/1-1.5:1.0/*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-hciuart@%k.service"
 # Revolution Pi bluetooth module: start the revpi-bthelper service
-ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-bthelper@%k.service"
+RESULT=="kunbus,revpi-flat", ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="revpi-bthelper@%k.service"


### PR DESCRIPTION
The revpi-bluetooth package is currently only needed for Revpi Flat. But
it will be part of the normal image. So we need to make sure the rules
are only running on RevPi Flat. As the bluetooth UART is connected via
USB on any other device a USB UART might get unumerated the same. So the
matching on the rules might not be enough to enforce this.

The rules match now also on the device compatible: kunbus,revpi-flat.
This ensures the rules are only run on the correct device.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>