### PR TITLE
fix: Discover gpiochip also on CM4s

### DIFF
--- a/usr/bin/revpi-btuart
+++ b/usr/bin/revpi-btuart
@@ -6,8 +6,8 @@ TTYDEVNAME="$1"
 
 # RevPi Flat: The BT_REG_ON signal is connected to the GPIO11 of the expander.
 BT_REG_ON_GPIO=11
-GPIOCHIP="$(basename /sys/devices/platform/soc/3f804000.i2c/i2c-1/1-0020/gpiochip?)"
-if [ "$GPIOCHIP" != "gpiochip*" ]; then
+GPIOCHIP="$(basename /sys/devices/platform/soc/*.i2c/i2c-1/1-0020/gpiochip?)"
+if [ "$GPIOCHIP" != "gpiochip?" ]; then
 	# Reset the bt module in RevPi Flat
 	gpioset "$GPIOCHIP" $BT_REG_ON_GPIO=0
 	sleep 0.1


### PR DESCRIPTION
Make gpiochip discovery more flexible and probe address for address of CM4s if
the address of the CM3 could not be found

ref REVPI-1831

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>