### PR TITLE
Use pkg-config to get the install paths for systemd service and udev files

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+include(FindPkgConfig)
+pkg_check_modules(SYSTEMD REQUIRED "systemd")
+pkg_get_variable(SYSTEMD_SYSTEMUNITDIR "systemd" "systemdsystemunitdir")
+
 install(FILES revpi-bthelper@.service revpi-hciuart@.service
-  DESTINATION /lib/systemd/system
+	DESTINATION ${SYSTEMD_SYSTEMUNITDIR}
 )

--- a/udev/CMakeLists.txt
+++ b/udev/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+include(FindPkgConfig)
+pkg_check_modules(UDEV REQUIRED "udev")
+pkg_get_variable(UDEV_UDEVDIR "udev" "udevdir")
+
 install(FILES 90-revpi-bluetooth.rules
-  DESTINATION /lib/udev/rules.d
+	DESTINATION ${UDEV_UDEVDIR}/rules.d
 )


### PR DESCRIPTION
Install tree:

```
pkg
├── lib
│   ├── systemd
│   │   └── system
│   │       ├── revpi-bthelper@.service
│   │       └── revpi-hciuart@.service
│   └── udev
│       └── rules.d
│           └── 90-revpi-bluetooth.rules
└── usr
    └── local
        ├── bin
        │   └── revpi-btuart
        └── sbin
            └── revpi-bthelper
```